### PR TITLE
Upgrade to .NET 8 for native macOS support

### DIFF
--- a/Databases.csproj
+++ b/Databases.csproj
@@ -2,15 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Retargets the project from the end-of-life **.NET Core 3.1** to the **.NET 8** LTS so it compiles and runs natively on modern macOS (including Apple Silicon), as well as other platforms.

### Why
- .NET Core 3.1 reached end of life on **Dec 13, 2022** and its SDK is no longer actively distributed.
- .NET Core 3.1 has **no native Apple Silicon (arm64) build** — it could only run under Rosetta with the x64 SDK, which is unsupported.
- .NET 8 is the current LTS with first-class macOS arm64/x64 support.

### Changes (`Databases.csproj` only)
- `TargetFramework`: `netcoreapp3.1` → `net8.0`
- `Microsoft.EntityFrameworkCore.Design`: `3.1.4` → `8.0.6`
- `Microsoft.EntityFrameworkCore.Sqlite`: `3.1.4` → `8.0.6`
- Explicitly set `Nullable` and `ImplicitUsings` to `disable` to preserve the existing C# semantics (the original code relied on the older language defaults).

No application code changes were required.

### Verification
Built and ran with the .NET 8 SDK (`8.0.422`):

- `dotnet build` → **Build succeeded. 0 Warning(s), 0 Error(s).**
- `dotnet run` → seeds and prints the 3 sample products successfully:

```
Product ID = 1	Title=Product 1	Product 2 subtitle	Date added=...
Product ID = 2	Title=Product 2	Product 2 subtitle	Date added=...
Product ID = 3	Title=Product 3	Product 2 subtitle	Date added=...
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1875-3949-7ed6-b95d-ae5c87e95b06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1875-3949-7ed6-b95d-ae5c87e95b06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

